### PR TITLE
chore: upgrade actions/create-github-app-token to v3, use client-id

### DIFF
--- a/.github/workflows/reusable-workflow-onboarder-close.yml
+++ b/.github/workflows/reusable-workflow-onboarder-close.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           template-path: .github/ISSUE_TEMPLATE/reusable-workflow-onboarder.yml
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/reusable-workflow-onboarder-create.yml
+++ b/.github/workflows/reusable-workflow-onboarder-create.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           template-path: .github/ISSUE_TEMPLATE/reusable-workflow-onboarder.yml
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/reusable-workflow-onboarder-merge.yml
+++ b/.github/workflows/reusable-workflow-onboarder-merge.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           template-path: .github/ISSUE_TEMPLATE/reusable-workflow-onboarder.yml
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/reusable-workflow-onboarder-prepare.yml
+++ b/.github/workflows/reusable-workflow-onboarder-prepare.yml
@@ -24,10 +24,10 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/reusable-workflow-onboarder-status.yml
+++ b/.github/workflows/reusable-workflow-onboarder-status.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           template-path: .github/ISSUE_TEMPLATE/reusable-workflow-onboarder.yml
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Summary

Upgrades `actions/create-github-app-token` to `@v3` and migrates from the deprecated `app-id` input to `client-id`.

### Changes
- ⬆️ Updated `actions/create-github-app-token` to `@v3`
- 🔄 Renamed input from `app-id` to `client-id` ([v3 changelog](https://github.com/actions/create-github-app-token/releases/tag/v3.0.0))
- 📝 Renamed variable references to use `*_CLIENT_ID` naming

### ✅ Variable Updates
- New variable(s) created: `APP_CLIENT_ID`
- Workflow updated to reference the new variable(s)

### 🧹 After Merging
Delete the old variable(s) that are no longer referenced: `APP_ID`